### PR TITLE
[agent] feat: rest day management — dedup, cancel, and mutual exclusion

### DIFF
--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -112,7 +112,10 @@ export const syncRoutes = new Elysia({ prefix: "/sync" })
       // Fetch updated previous_sets for exercises in this workout
       const exerciseIds = body.exercises.map((e) => e.exercise_id);
 
-      const previousSetsRows = exerciseIds.length === 0 ? [] : await sql`
+      const previousSetsRows =
+        exerciseIds.length === 0
+          ? []
+          : await sql`
         WITH ranked_sets AS (
             SELECT s.exercise_id, s.profile_id, s.reps, s.weight, s.weight_unit, s.side, s.created_at,
                 DENSE_RANK() OVER (

--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -58,6 +58,21 @@ export const syncRoutes = new Elysia({ prefix: "/sync" })
   .post(
     "/workout",
     async ({ userId, body }) => {
+      // Dedup check for rest days
+      if (body.kind === "rest") {
+        const startDate = new Date(body.start_time);
+        const existing = await sql`
+          SELECT id FROM workouts
+          WHERE user_id = ${userId}
+            AND kind = 'rest'
+            AND (start_time AT TIME ZONE 'UTC')::date = ${startDate.toISOString()}::date
+          LIMIT 1
+        `;
+        if (existing.length > 0) {
+          return { workout_id: existing[0].id, previous_sets: {} };
+        }
+      }
+
       const workoutId = await db.transaction(async (tx) => {
         // 1. Create the workout
         const [workout] = await tx
@@ -97,7 +112,7 @@ export const syncRoutes = new Elysia({ prefix: "/sync" })
       // Fetch updated previous_sets for exercises in this workout
       const exerciseIds = body.exercises.map((e) => e.exercise_id);
 
-      const previousSetsRows = await sql`
+      const previousSetsRows = exerciseIds.length === 0 ? [] : await sql`
         WITH ranked_sets AS (
             SELECT s.exercise_id, s.profile_id, s.reps, s.weight, s.weight_unit, s.side, s.created_at,
                 DENSE_RANK() OVER (

--- a/apps/mobile/app/(tabs)/workout.tsx
+++ b/apps/mobile/app/(tabs)/workout.tsx
@@ -1,16 +1,20 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { View, Text, Pressable, Alert } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import PagerView from "react-native-pager-view";
 import { Ionicons } from "@expo/vector-icons";
 
+import { useQueryClient } from "@tanstack/react-query";
 import { useWorkout } from "../../hooks/useWorkout";
+import { useWorkouts } from "../../hooks/useWorkouts";
 import { useSync } from "../../hooks/useSync";
 import { useThemeColors } from "../../hooks/useThemeColors";
 import {
+  getLocalDateString,
   getWorkoutLastSlide,
   setWorkoutLastSlide,
 } from "../../services/storage";
+import { api } from "../../lib/api";
 import ExerciseSlide from "../../components/workout/ExerciseSlide";
 import AddExerciseSlide from "../../components/workout/AddExerciseSlide";
 import WorkoutSummary from "../../components/workout/WorkoutSummary";
@@ -32,14 +36,27 @@ export default function WorkoutScreen() {
   const {
     workout,
     isActive,
+    todayRestDay,
     startWorkout,
     logRestDay,
+    cancelRestDay,
+    reconcileRestDay,
     removeExercise,
     finishWorkout,
     cancelWorkout,
   } = useWorkout();
   const { forceSync } = useSync();
   const colors = useThemeColors();
+  const queryClient = useQueryClient();
+  const { data: serverWorkouts } = useWorkouts(1, 20);
+
+  const todayHasWorkouts = useMemo(() => {
+    if (!serverWorkouts) return false;
+    const today = getLocalDateString();
+    return serverWorkouts.some(
+      (w: any) => getLocalDateString(w.startTime) === today && w.kind === "workout",
+    );
+  }, [serverWorkouts]);
 
   const pagerRef = useRef<PagerView>(null);
   const [activeSlide, setActiveSlide] = useState(0);
@@ -80,6 +97,13 @@ export default function WorkoutScreen() {
       setActiveSlide(maxIndex);
     }
   }, [workoutId, exerciseCount, activeSlide]);
+
+  // Reconcile local rest day state with server data
+  useEffect(() => {
+    if (serverWorkouts) {
+      reconcileRestDay(serverWorkouts);
+    }
+  }, [serverWorkouts, reconcileRestDay]);
 
   const handlePageSelected = useCallback(
     (e: { nativeEvent: { position: number } }) => {
@@ -155,7 +179,50 @@ export default function WorkoutScreen() {
     forceSync();
   }, [logRestDay, forceSync]);
 
+  const handleCancelRestDay = useCallback(async () => {
+    const syncedWorkoutId = cancelRestDay();
+    if (syncedWorkoutId) {
+      try {
+        await (api.api.v1.workouts as any)[syncedWorkoutId].delete();
+      } catch {
+        // Best-effort — server reconciliation will clean up
+      }
+    }
+    queryClient.invalidateQueries({ queryKey: ["workouts"] });
+    queryClient.invalidateQueries({ queryKey: ["streak"] });
+    queryClient.invalidateQueries({ queryKey: ["all-time-stats"] });
+  }, [cancelRestDay, queryClient]);
+
   const isOnExerciseSlide = workout !== null && activeSlide < exerciseCount;
+
+  // --- Rest day state ---
+  if (!isActive && todayRestDay) {
+    return (
+      <SafeAreaView className="flex-1 bg-white dark:bg-zinc-900" edges={["top"]}>
+        <View className="px-4 pb-2 pt-4">
+          <Text className="text-3xl font-bold dark:text-zinc-100">Rest Day</Text>
+        </View>
+        <View className="flex-1 items-center justify-center px-6">
+          <Ionicons name="bed-outline" size={64} color={colors.secondaryText} />
+          <Text className="mt-4 mb-2 text-xl font-semibold dark:text-zinc-100">
+            You're resting today
+          </Text>
+          <Text className="mb-6 text-center text-base text-zinc-500 dark:text-zinc-400">
+            Recovery is part of the process.
+          </Text>
+          <Pressable
+            onPress={handleCancelRestDay}
+            className="w-full flex-row items-center justify-center gap-2 rounded-lg border border-red-300 dark:border-red-800 py-3.5 active:bg-red-50 dark:active:bg-red-950"
+          >
+            <Ionicons name="close-circle-outline" size={18} color={colors.dangerIcon} />
+            <Text className="text-base font-semibold text-red-500 dark:text-red-400">
+              Cancel Rest Day
+            </Text>
+          </Pressable>
+        </View>
+      </SafeAreaView>
+    );
+  }
 
   // --- Idle state (no active workout) ---
   if (!isActive) {
@@ -177,15 +244,17 @@ export default function WorkoutScreen() {
               Start Workout
             </Text>
           </Pressable>
-          <Pressable
-            onPress={handleLogRestDay}
-            className="w-full flex-row items-center justify-center gap-2 rounded-lg border border-zinc-300 dark:border-zinc-600 py-3.5 active:bg-zinc-50 dark:active:bg-zinc-800"
-          >
-            <Ionicons name="bed-outline" size={18} color={colors.secondaryText} />
-            <Text className="text-base font-semibold text-zinc-600 dark:text-zinc-300">
-              Log Rest Day
-            </Text>
-          </Pressable>
+          {!todayHasWorkouts && (
+            <Pressable
+              onPress={handleLogRestDay}
+              className="w-full flex-row items-center justify-center gap-2 rounded-lg border border-zinc-300 dark:border-zinc-600 py-3.5 active:bg-zinc-50 dark:active:bg-zinc-800"
+            >
+              <Ionicons name="bed-outline" size={18} color={colors.secondaryText} />
+              <Text className="text-base font-semibold text-zinc-600 dark:text-zinc-300">
+                Log Rest Day
+              </Text>
+            </Pressable>
+          )}
         </View>
       </SafeAreaView>
     );

--- a/apps/mobile/app/(tabs)/workout.tsx
+++ b/apps/mobile/app/(tabs)/workout.tsx
@@ -54,7 +54,8 @@ export default function WorkoutScreen() {
     if (!serverWorkouts) return false;
     const today = getLocalDateString();
     return serverWorkouts.some(
-      (w: any) => getLocalDateString(w.startTime) === today && w.kind === "workout",
+      (w: any) =>
+        getLocalDateString(w.startTime) === today && w.kind === "workout",
     );
   }, [serverWorkouts]);
 
@@ -198,9 +199,14 @@ export default function WorkoutScreen() {
   // --- Rest day state ---
   if (!isActive && todayRestDay) {
     return (
-      <SafeAreaView className="flex-1 bg-white dark:bg-zinc-900" edges={["top"]}>
+      <SafeAreaView
+        className="flex-1 bg-white dark:bg-zinc-900"
+        edges={["top"]}
+      >
         <View className="px-4 pb-2 pt-4">
-          <Text className="text-3xl font-bold dark:text-zinc-100">Rest Day</Text>
+          <Text className="text-3xl font-bold dark:text-zinc-100">
+            Rest Day
+          </Text>
         </View>
         <View className="flex-1 items-center justify-center px-6">
           <Ionicons name="bed-outline" size={64} color={colors.secondaryText} />
@@ -214,7 +220,11 @@ export default function WorkoutScreen() {
             onPress={handleCancelRestDay}
             className="w-full flex-row items-center justify-center gap-2 rounded-lg border border-red-300 dark:border-red-800 py-3.5 active:bg-red-50 dark:active:bg-red-950"
           >
-            <Ionicons name="close-circle-outline" size={18} color={colors.dangerIcon} />
+            <Ionicons
+              name="close-circle-outline"
+              size={18}
+              color={colors.dangerIcon}
+            />
             <Text className="text-base font-semibold text-red-500 dark:text-red-400">
               Cancel Rest Day
             </Text>
@@ -227,12 +237,17 @@ export default function WorkoutScreen() {
   // --- Idle state (no active workout) ---
   if (!isActive) {
     return (
-      <SafeAreaView className="flex-1 bg-white dark:bg-zinc-900" edges={["top"]}>
+      <SafeAreaView
+        className="flex-1 bg-white dark:bg-zinc-900"
+        edges={["top"]}
+      >
         <View className="px-4 pb-2 pt-4">
           <Text className="text-3xl font-bold dark:text-zinc-100">Workout</Text>
         </View>
         <View className="flex-1 items-center justify-center px-6">
-          <Text className="mb-2 text-xl font-semibold dark:text-zinc-100">Ready to train?</Text>
+          <Text className="mb-2 text-xl font-semibold dark:text-zinc-100">
+            Ready to train?
+          </Text>
           <Text className="mb-6 text-center text-base text-zinc-500 dark:text-zinc-400">
             Start a new workout session to begin logging your exercises.
           </Text>
@@ -249,7 +264,11 @@ export default function WorkoutScreen() {
               onPress={handleLogRestDay}
               className="w-full flex-row items-center justify-center gap-2 rounded-lg border border-zinc-300 dark:border-zinc-600 py-3.5 active:bg-zinc-50 dark:active:bg-zinc-800"
             >
-              <Ionicons name="bed-outline" size={18} color={colors.secondaryText} />
+              <Ionicons
+                name="bed-outline"
+                size={18}
+                color={colors.secondaryText}
+              />
               <Text className="text-base font-semibold text-zinc-600 dark:text-zinc-300">
                 Log Rest Day
               </Text>
@@ -274,7 +293,11 @@ export default function WorkoutScreen() {
             onPress={() => setShowReorder(true)}
             className="h-9 w-9 items-center justify-center rounded-md active:bg-zinc-100 dark:active:bg-zinc-800"
           >
-            <Ionicons name="reorder-four" size={22} color={colors.secondaryText} />
+            <Ionicons
+              name="reorder-four"
+              size={22}
+              color={colors.secondaryText}
+            />
           </Pressable>
           {/* Remove current exercise button */}
           {isOnExerciseSlide && (
@@ -282,7 +305,11 @@ export default function WorkoutScreen() {
               onPress={handleRemoveCurrentExercise}
               className="h-9 w-9 items-center justify-center rounded-md active:bg-red-50 dark:active:bg-red-950"
             >
-              <Ionicons name="trash-outline" size={20} color={colors.dangerIcon} />
+              <Ionicons
+                name="trash-outline"
+                size={20}
+                color={colors.dangerIcon}
+              />
             </Pressable>
           )}
         </View>
@@ -318,7 +345,10 @@ export default function WorkoutScreen() {
             className="h-1.5 rounded-full"
             style={{
               width: i === activeSlide ? 16 : 6,
-              backgroundColor: i === activeSlide ? colors.activeIndicator : colors.inactiveIndicator,
+              backgroundColor:
+                i === activeSlide
+                  ? colors.activeIndicator
+                  : colors.inactiveIndicator,
             }}
           />
         ))}
@@ -327,7 +357,9 @@ export default function WorkoutScreen() {
           style={{
             width: activeSlide === exerciseCount ? 16 : 6,
             backgroundColor:
-              activeSlide === exerciseCount ? colors.activeIndicator : colors.inactiveIndicator,
+              activeSlide === exerciseCount
+                ? colors.activeIndicator
+                : colors.inactiveIndicator,
           }}
         />
       </View>

--- a/apps/mobile/app/(tabs)/workout.tsx
+++ b/apps/mobile/app/(tabs)/workout.tsx
@@ -176,22 +176,41 @@ export default function WorkoutScreen() {
   }, [workout, activeSlide, removeExercise]);
 
   const handleLogRestDay = useCallback(() => {
-    logRestDay();
-    forceSync();
+    const result = logRestDay();
+    if (result) forceSync();
   }, [logRestDay, forceSync]);
 
-  const handleCancelRestDay = useCallback(async () => {
-    const syncedWorkoutId = cancelRestDay();
-    if (syncedWorkoutId) {
-      try {
-        await (api.api.v1.workouts as any)[syncedWorkoutId].delete();
-      } catch {
-        // Best-effort — server reconciliation will clean up
-      }
-    }
-    queryClient.invalidateQueries({ queryKey: ["workouts"] });
-    queryClient.invalidateQueries({ queryKey: ["streak"] });
-    queryClient.invalidateQueries({ queryKey: ["all-time-stats"] });
+  const handleCancelRestDay = useCallback(() => {
+    Alert.alert(
+      "Cancel Rest Day",
+      "Are you sure you want to cancel your rest day?",
+      [
+        { text: "No", style: "cancel" },
+        {
+          text: "Cancel Rest Day",
+          style: "destructive",
+          onPress: async () => {
+            const syncedWorkoutId = cancelRestDay();
+            if (syncedWorkoutId) {
+              // Optimistically remove from query cache to prevent reconciliation re-adoption
+              queryClient.setQueryData(
+                ["workouts", 1, 20],
+                (old: any[] | undefined) =>
+                  old?.filter((w: any) => w.id !== syncedWorkoutId),
+              );
+              try {
+                await (api.api.v1.workouts as any)[syncedWorkoutId].delete();
+              } catch {
+                // Best-effort
+              }
+            }
+            queryClient.invalidateQueries({ queryKey: ["workouts"] });
+            queryClient.invalidateQueries({ queryKey: ["streak"] });
+            queryClient.invalidateQueries({ queryKey: ["all-time-stats"] });
+          },
+        },
+      ],
+    );
   }, [cancelRestDay, queryClient]);
 
   const isOnExerciseSlide = workout !== null && activeSlide < exerciseCount;

--- a/apps/mobile/hooks/useSync.tsx
+++ b/apps/mobile/hooks/useSync.tsx
@@ -3,12 +3,15 @@ import { useCallback, useMemo } from "react";
 import {
   getLastSyncTime,
   getPendingWorkout,
+  getTodayRestDay,
+  setTodayRestDay,
   type StoredWorkout,
   setLastSyncTime,
   setPendingWorkout,
   updatePreviousSets,
   generateId,
 } from "../services/storage";
+import { api } from "../lib/api";
 import { useSyncedSave } from "./useSyncedSave";
 import { useSyncWorkout } from "./useSyncWorkout";
 
@@ -78,7 +81,26 @@ export function useSync() {
 
   // Handle successful sync - update previous sets cache
   const onSyncSuccess = useCallback(
-    async (response: any) => {
+    async (response: any, localData: StoredWorkout) => {
+      // Handle rest day sync completion
+      if (localData.kind === "rest") {
+        const currentRestDay = getTodayRestDay();
+        if (currentRestDay) {
+          // Rest day still active — save the synced server ID
+          setTodayRestDay({
+            ...currentRestDay,
+            syncedWorkoutId: response.workout_id,
+          });
+        } else {
+          // User cancelled while sync was in-flight — delete from server
+          try {
+            await (api.api.v1.workouts as any)[response.workout_id].delete();
+          } catch {
+            // Best-effort cleanup
+          }
+        }
+      }
+
       if (response.previous_sets) {
         for (const [key, sets] of Object.entries(
           response.previous_sets as Record<string, any[]>,

--- a/apps/mobile/hooks/useWorkout.tsx
+++ b/apps/mobile/hooks/useWorkout.tsx
@@ -9,13 +9,18 @@ import {
 import { detectAndSetNearbyGym } from "../services/geolocation";
 import {
   addExerciseSequence,
+  clearTodayRestDay,
   generateId,
   getCurrentWorkout,
+  getLocalDateString,
   getPendingWorkout,
   getSettings,
+  getTodayRestDay,
+  setTodayRestDay,
   type StoredSet,
   type StoredWorkout,
   type StoredWorkoutExercise,
+  type TodayRestDay,
   setCurrentWorkout,
   setPendingWorkout,
   updatePreviousSets,
@@ -24,8 +29,11 @@ import {
 interface WorkoutContextValue {
   workout: StoredWorkout | null;
   isActive: boolean;
+  todayRestDay: TodayRestDay | null;
   startWorkout: () => void;
-  logRestDay: () => StoredWorkout;
+  logRestDay: () => StoredWorkout | null;
+  cancelRestDay: () => string | undefined;
+  reconcileRestDay: (serverWorkouts: any[]) => void;
   addExercise: (
     exerciseId: string,
     exerciseName: string,
@@ -71,6 +79,7 @@ const WorkoutContext = createContext<WorkoutContextValue | null>(null);
 export function WorkoutProvider({ children }: { children: ReactNode }) {
   const [workout, setWorkout] = useState<StoredWorkout | null>(null);
   const [hasPendingWorkout, setHasPendingWorkout] = useState(false);
+  const [todayRestDayState, setTodayRestDayState] = useState<TodayRestDay | null>(null);
 
   // Load current workout on mount (MMKV is synchronous)
   useEffect(() => {
@@ -102,6 +111,14 @@ export function WorkoutProvider({ children }: { children: ReactNode }) {
         setWorkout(current);
       }
     }
+
+    // Load today's rest day from storage
+    const storedRestDay = getTodayRestDay();
+    if (storedRestDay && storedRestDay.date === getLocalDateString()) {
+      setTodayRestDayState(storedRestDay);
+    } else if (storedRestDay) {
+      clearTodayRestDay(); // Stale — different day
+    }
   }, []);
 
   const saveWorkout = useCallback((w: StoredWorkout | null) => {
@@ -110,6 +127,8 @@ export function WorkoutProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const startWorkout = useCallback(() => {
+    if (todayRestDayState) return; // Can't start workout on a rest day
+
     const settings = getSettings();
     const newWorkout: StoredWorkout = {
       id: generateId(),
@@ -122,9 +141,11 @@ export function WorkoutProvider({ children }: { children: ReactNode }) {
 
     // Auto-detect nearby gym (fire-and-forget)
     detectAndSetNearbyGym().catch(() => {});
-  }, [saveWorkout]);
+  }, [saveWorkout, todayRestDayState]);
 
-  const logRestDay = useCallback((): StoredWorkout => {
+  const logRestDay = useCallback((): StoredWorkout | null => {
+    if (todayRestDayState) return null; // Already a rest day today
+
     const settings = getSettings();
     const now = new Date().toISOString();
     const restDay: StoredWorkout = {
@@ -136,10 +157,66 @@ export function WorkoutProvider({ children }: { children: ReactNode }) {
       name: "Rest Day",
     };
 
+    const pointer: TodayRestDay = {
+      workoutId: restDay.id,
+      date: getLocalDateString(),
+      startTime: now,
+    };
+    setTodayRestDay(pointer);
+    setTodayRestDayState(pointer);
+
     setPendingWorkout(restDay);
     setHasPendingWorkout(true);
 
     return restDay;
+  }, [todayRestDayState]);
+
+  const cancelRestDay = useCallback((): string | undefined => {
+    const current = getTodayRestDay();
+    const syncedId = current?.syncedWorkoutId;
+
+    clearTodayRestDay();
+    setTodayRestDayState(null);
+
+    // Clear pending if not yet synced
+    const pending = getPendingWorkout();
+    if (pending && pending.kind === "rest") {
+      setPendingWorkout(null);
+      setHasPendingWorkout(false);
+    }
+
+    return syncedId;
+  }, []);
+
+  const reconcileRestDay = useCallback((serverWorkouts: any[]) => {
+    const today = getLocalDateString();
+    const serverRestDay = serverWorkouts.find((w: any) => {
+      return getLocalDateString(w.startTime) === today && w.kind === "rest";
+    });
+
+    const local = getTodayRestDay();
+
+    if (serverRestDay && !local) {
+      // Server has rest day, local doesn't — adopt (logged on another device)
+      const pointer: TodayRestDay = {
+        workoutId: serverRestDay.id,
+        date: today,
+        startTime: serverRestDay.startTime,
+        syncedWorkoutId: serverRestDay.id,
+      };
+      setTodayRestDay(pointer);
+      setTodayRestDayState(pointer);
+    } else if (local && serverRestDay && !local.syncedWorkoutId) {
+      // Local was pending, server now has it — update with server ID
+      const updated: TodayRestDay = {
+        ...local,
+        syncedWorkoutId: serverRestDay.id,
+      };
+      setTodayRestDay(updated);
+      setTodayRestDayState(updated);
+    }
+    // If local has rest day but server doesn't → still pending sync, keep local
+    // If neither has rest day → nothing to do
   }, []);
 
   const addExercise = useCallback(
@@ -521,8 +598,11 @@ export function WorkoutProvider({ children }: { children: ReactNode }) {
       value={{
         workout,
         isActive: workout !== null,
+        todayRestDay: todayRestDayState,
         startWorkout,
         logRestDay,
+        cancelRestDay,
+        reconcileRestDay,
         addExercise,
         removeExercise,
         reorderExercises,

--- a/apps/mobile/hooks/useWorkout.tsx
+++ b/apps/mobile/hooks/useWorkout.tsx
@@ -79,7 +79,8 @@ const WorkoutContext = createContext<WorkoutContextValue | null>(null);
 export function WorkoutProvider({ children }: { children: ReactNode }) {
   const [workout, setWorkout] = useState<StoredWorkout | null>(null);
   const [hasPendingWorkout, setHasPendingWorkout] = useState(false);
-  const [todayRestDayState, setTodayRestDayState] = useState<TodayRestDay | null>(null);
+  const [todayRestDayState, setTodayRestDayState] =
+    useState<TodayRestDay | null>(null);
 
   // Load current workout on mount (MMKV is synchronous)
   useEffect(() => {
@@ -97,8 +98,7 @@ export function WorkoutProvider({ children }: { children: ReactNode }) {
       if (minutesDiff > settings.maxWorkoutDurationMinutes) {
         // Auto-cap the workout
         const cappedEndTime = new Date(
-          startTime.getTime() +
-            settings.maxWorkoutDurationMinutes * 60 * 1000,
+          startTime.getTime() + settings.maxWorkoutDurationMinutes * 60 * 1000,
         );
         const cappedWorkout = {
           ...current,

--- a/apps/mobile/hooks/useWorkout.tsx
+++ b/apps/mobile/hooks/useWorkout.tsx
@@ -214,6 +214,21 @@ export function WorkoutProvider({ children }: { children: ReactNode }) {
       };
       setTodayRestDay(updated);
       setTodayRestDayState(updated);
+    } else if (
+      local &&
+      serverRestDay &&
+      local.syncedWorkoutId &&
+      local.syncedWorkoutId !== serverRestDay.id
+    ) {
+      // Both exist with different IDs (e.g., re-created from another device) — server wins
+      const pointer: TodayRestDay = {
+        workoutId: serverRestDay.id,
+        date: today,
+        startTime: serverRestDay.startTime,
+        syncedWorkoutId: serverRestDay.id,
+      };
+      setTodayRestDay(pointer);
+      setTodayRestDayState(pointer);
     }
     // If local has rest day but server doesn't → still pending sync, keep local
     // If neither has rest day → nothing to do

--- a/apps/mobile/services/storage.ts
+++ b/apps/mobile/services/storage.ts
@@ -50,6 +50,7 @@ export const STORAGE_KEYS = {
   CURRENT_GYM: "current_gym",
   GYM_PROFILE_MAP: "gym_profile_map",
   EXERCISE_SEQUENCES: "exercise_sequences",
+  TODAY_REST_DAY: "today_rest_day",
 } as const;
 
 // Workout kind type
@@ -168,6 +169,13 @@ export interface ExerciseSequenceEntry {
 
 // Stored exercise sequences from recent workouts (most recent first, max 20)
 export type StoredExerciseSequences = ExerciseSequenceEntry[];
+
+export interface TodayRestDay {
+  workoutId: string;        // local StoredWorkout.id
+  date: string;             // YYYY-MM-DD for staleness check
+  startTime: string;        // ISO timestamp for multi-device dedup
+  syncedWorkoutId?: string; // server workout ID after sync
+}
 
 // Default settings
 export const DEFAULT_SETTINGS: StoredSettings = {
@@ -446,4 +454,25 @@ export function getLastProfileForExerciseAtGym(
   const map = getGymProfileMap();
   const key = `${exerciseId}_${gymId}`;
   return map[key] ?? null;
+}
+
+// --- Date helpers ---
+
+export function getLocalDateString(date?: Date | string): string {
+  const d = date ? (typeof date === "string" ? new Date(date) : date) : new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+// --- Today rest day operations ---
+
+export function getTodayRestDay(): TodayRestDay | null {
+  return getJSON<TodayRestDay>(STORAGE_KEYS.TODAY_REST_DAY);
+}
+
+export function setTodayRestDay(data: TodayRestDay): void {
+  setJSON(STORAGE_KEYS.TODAY_REST_DAY, data);
+}
+
+export function clearTodayRestDay(): void {
+  deleteKey(STORAGE_KEYS.TODAY_REST_DAY);
 }

--- a/apps/mobile/services/storage.ts
+++ b/apps/mobile/services/storage.ts
@@ -171,9 +171,9 @@ export interface ExerciseSequenceEntry {
 export type StoredExerciseSequences = ExerciseSequenceEntry[];
 
 export interface TodayRestDay {
-  workoutId: string;        // local StoredWorkout.id
-  date: string;             // YYYY-MM-DD for staleness check
-  startTime: string;        // ISO timestamp for multi-device dedup
+  workoutId: string; // local StoredWorkout.id
+  date: string; // YYYY-MM-DD for staleness check
+  startTime: string; // ISO timestamp for multi-device dedup
   syncedWorkoutId?: string; // server workout ID after sync
 }
 
@@ -245,7 +245,10 @@ export function clearWorkoutLastSlide(): void {
 }
 
 export function getSettings(): StoredSettings {
-  return { ...DEFAULT_SETTINGS, ...getJSON<StoredSettings>(STORAGE_KEYS.SETTINGS) };
+  return {
+    ...DEFAULT_SETTINGS,
+    ...getJSON<StoredSettings>(STORAGE_KEYS.SETTINGS),
+  };
 }
 
 export function setSettings(settings: StoredSettings): void {
@@ -433,10 +436,7 @@ export function getExerciseSequences(): StoredExerciseSequences {
   return raw as StoredExerciseSequences;
 }
 
-export function addExerciseSequence(
-  sequence: string[],
-  title?: string,
-): void {
+export function addExerciseSequence(sequence: string[], title?: string): void {
   if (sequence.length === 0) return;
   const sequences = getExerciseSequences();
   sequences.unshift({ exerciseIds: sequence, title });
@@ -459,7 +459,11 @@ export function getLastProfileForExerciseAtGym(
 // --- Date helpers ---
 
 export function getLocalDateString(date?: Date | string): string {
-  const d = date ? (typeof date === "string" ? new Date(date) : date) : new Date();
+  const d = date
+    ? typeof date === "string"
+      ? new Date(date)
+      : date
+    : new Date();
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }
 


### PR DESCRIPTION
## Summary

- **Prevents duplicate rest days** per user per day (client-side + server-side dedup safety net)
- **Mutual exclusion**: a day is either a rest day or not — can't log rest day when workouts exist, can't start workout on a rest day
- **Rest Day tab view**: logging a rest day immediately flips the workout tab to a "Rest Day" view with a cancel button and confirmation dialog
- **Cancel support**: fully undoes the rest day (clears local state + DELETEs from server)
- **Multi-device reconciliation**: hybrid local-first + server sync with timestamp-based dedup

Resolves #1

## Changes

| File | What |
|------|------|
| `services/storage.ts` | `TodayRestDay` type, CRUD helpers, `getLocalDateString` utility |
| `routes/sync.ts` | Server-side dedup: rejects duplicate rest days per user+date |
| `hooks/useWorkout.tsx` | `todayRestDay` state, `logRestDay` (with dedup), `cancelRestDay`, `reconcileRestDay`, `startWorkout` guard |
| `hooks/useSync.tsx` | Saves `syncedWorkoutId` after rest day sync; handles cancel-while-syncing race |
| `app/(tabs)/workout.tsx` | Three render states (rest day / idle / active), reconciliation effect, cancel handler with confirmation dialog, conditional "Log Rest Day" button |

## Test plan

- [ ] Log a rest day — workout tab immediately shows "Rest Day" view
- [ ] Cancel rest day — confirmation dialog appears, tab returns to idle, rest day deleted from server
- [ ] Log a rest day, close and reopen app — rest day view persists
- [ ] Log a rest day on day 1, open app on day 2 — stale rest day is cleared
- [ ] Complete a workout, then check idle state — "Log Rest Day" button is hidden
- [ ] Log a rest day, try starting a workout programmatically — blocked by guard
- [ ] Log rest day twice rapidly — only one created (client-side dedup)
- [ ] Sync the same rest day from two devices — only one stored (server-side dedup)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>