### PR TITLE
fix: turn off auto remove empty set when auto add set is disabled

### DIFF
--- a/apps/mobile/app/(tabs)/settings/index.tsx
+++ b/apps/mobile/app/(tabs)/settings/index.tsx
@@ -406,13 +406,17 @@ export default function SettingsScreen() {
             <Text className="text-base dark:text-zinc-100">Auto Add Set</Text>
             <Switch
               value={settings.autoAddSet}
-              onValueChange={(v) => updateSettings({ autoAddSet: v })}
+              onValueChange={(v) =>
+                updateSettings(
+                  v ? { autoAddSet: true } : { autoAddSet: false, autoRemoveEmptySet: false },
+                )
+              }
             />
           </SettingsRow>
           <SettingsRow last>
             <Text className="text-base dark:text-zinc-100">Auto Remove Empty Set</Text>
             <Switch
-              value={settings.autoRemoveEmptySet}
+              value={settings.autoAddSet && settings.autoRemoveEmptySet}
               onValueChange={(v) => updateSettings({ autoRemoveEmptySet: v })}
               disabled={!settings.autoAddSet}
             />

--- a/apps/mobile/components/workout/ExerciseSlide.tsx
+++ b/apps/mobile/components/workout/ExerciseSlide.tsx
@@ -240,9 +240,15 @@ export default function ExerciseSlide({ exercise }: ExerciseSlideProps) {
   );
 
   const handleSetBlur = useCallback(() => {
-    if (mode !== "live" || !settings.autoRemoveEmptySet) return;
+    if (mode !== "live" || !settings.autoAddSet || !settings.autoRemoveEmptySet) return;
     trimTrailingEmptySets(exercise.exerciseId, 1);
-  }, [mode, settings.autoRemoveEmptySet, trimTrailingEmptySets, exercise.exerciseId]);
+  }, [
+    mode,
+    settings.autoAddSet,
+    settings.autoRemoveEmptySet,
+    trimTrailingEmptySets,
+    exercise.exerciseId,
+  ]);
 
   const lastSet = exercise.sets[exercise.sets.length - 1];
   const lastRightSet = exercise.isUnilateral


### PR DESCRIPTION
Disabling Auto Add Set now writes autoRemoveEmptySet: false instead of
leaving the dependent toggle locked to its previous value. The switch
also renders off whenever Auto Add Set is off, and the trailing-empty-set
trim in ExerciseSlide is gated on both flags so already-persisted
settings behave the same way.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MoaxcVieXKfMLuR7Jwx5TQ